### PR TITLE
Remo function name from map keys

### DIFF
--- a/cmd/testtime/_partials/testtime.go
+++ b/cmd/testtime/_partials/testtime.go
@@ -2,32 +2,14 @@
 
 var timeMap sync.Map
 
+// Now returns a fixed time which is related with the goroutine by SetTime or SetFunc.
+// If the current goroutine is not related with any fixed time or function, Now calls time.Now and returns its returned value.
 func Now() Time {
-	pcs := make([]uintptr, 10)
-	n := runtime.Callers(1, pcs)
-	frames := runtime.CallersFrames(pcs[:n])
-	for {
-		frame, hasNext := frames.Next()
-		v, ok := timeMap.Load(goroutineID() + ":" + frame.Function)
-		if ok {
-			return v.(func() Time)()
-		}
-
-		if !hasNext {
-			break
-		}
+	v, ok := timeMap.Load(goroutineID())
+	if ok {
+		return v.(func() Time)()
 	}
 	return _Now()
-}
-
-func funcName(skip int) (string, bool) {
-	pc, _, _, ok := runtime.Caller(skip + 1)
-	if !ok {
-		return "", false
-	}
-	fnc := runtime.FuncForPC(pc)
-
-	return goroutineID() + ":" + fnc.Name(), true
 }
 
 func goroutineID() string {

--- a/time_test.go
+++ b/time_test.go
@@ -9,40 +9,35 @@ import (
 )
 
 func Test(t *testing.T) {
-	func() {
-		testtime.SetTime(t, time.Time{})
-		if !testtime.Now().IsZero() {
-			t.Error("testtime.Now() must be zero value")
+
+	t.Run("SetTime", func(t *testing.T) {
+		tm := parseTime(t, "2022/11/17 17:21:00")
+		testtime.SetTime(t, tm)
+		if !testtime.Now().Equal(tm) {
+			t.Error("testtime.Now() must be", tm)
 		}
+	})
 
-		if !testtime.Now().IsZero() {
-			t.Error("testtime.Now() must be zero value")
+	t.Run("SetFunc", func(t *testing.T) {
+		tm := parseTime(t, "2022/11/17 17:23:00")
+		testtime.SetFunc(t, func() time.Time { return tm })
+
+		if !testtime.Now().Equal(tm) {
+			t.Error("testtime.Now() must be", tm)
 		}
+	})
 
-		func() {
-			if !testtime.Now().IsZero() {
-				t.Error("testtime.Now() must be zero value")
-			}
-		}()
-
-		done := make(chan struct{})
-		go func() {
-			if testtime.Now().IsZero() {
-				t.Error("testtime.Now() must not be zero value")
-			}
-			close(done)
-		}()
-		<-done
-	}()
-
-	func() {
-		testtime.SetFunc(t, func() time.Time { return time.Time{} })
-		if !testtime.Now().IsZero() {
-			t.Error("testtime.Now() must be zero value")
-		}
-	}()
-
-	if testtime.Now().IsZero() {
-		t.Error("testtime.Now() must not be zero value")
+	testtime.SetTime(t, time.Time{})
+	if !testtime.Now().IsZero() {
+		t.Error("testtime.Now() must be zero value")
 	}
+}
+
+func parseTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	tm, err := time.Parse("2006/01/02 15:04:05", s)
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+	return tm
 }


### PR DESCRIPTION
For simplification keys and cutting cost of for loop a map key change from goroutineID + ":" + funcname to goroutineID.