### PR TITLE
fix go:linkname issue

### DIFF
--- a/cmd/testtime/_partials/testtime.go
+++ b/cmd/testtime/_partials/testtime.go
@@ -1,5 +1,6 @@
 // It will be added to GOROOT/src/time/time.go.
 
+//go:linkname timeMap
 var timeMap sync.Map
 
 // Now returns a fixed time which is related with the goroutine by SetTime or SetFunc.


### PR DESCRIPTION
close #14 

with Go 1.23rc1, the testtime command doesn't work correctly.

```console
% go1.23rc1 install github.com/tenntenn/testtime/cmd/testtime@latest
% cd _examples/greeting
% go1.23rc1 test -overlay=`testtime`
# greeting.test
link: github.com/tenntenn/testtime: invalid reference to time.timeMap
FAIL	greeting [build failed]
```

This pull request fixes it.

```console
% go1.23rc1 install ./cmd/testtime
% cd _examples/greeting
% go1.23rc1 test -overlay=`testtime -u`
PASS
ok  	greeting	0.586s
```